### PR TITLE
Anpassung Icon Dashboard

### DIFF
--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -44,7 +44,7 @@
         <div class="card">
             <a href="{{ path('current_status') }}" class="card-body d-flex align-items-center">
                 <div class="icon text-center mr-3 flex-shrink-0 bg-primary">
-                    <i class="far fa-question-circle"></i>
+                    <i class="fas fa-question-circle"></i>
                 </div>
                 <p class="m-0">{{ 'dashboard.status.overall'|trans }}</p>
             </a>


### PR DESCRIPTION
## Beschreibung

Das Icon ist in Ursprungsform das einzige, das als Outline dargestellt wird. In der ausgefüllten Variante ist es im gleichen Stil wie die anderen Icons.

## Ansicht
Vorher:
<img width="353" alt="Bildschirmfoto 2021-08-31 um 08 07 57" src="https://user-images.githubusercontent.com/74987472/131462818-fd6e574c-d68e-4188-b7bb-e5ad8c775f8b.png">

Nachher:
<img width="353" alt="Bildschirmfoto 2021-08-31 um 08 07 47" src="https://user-images.githubusercontent.com/74987472/131462815-5d43f321-8720-467e-9f74-1c157a4916ac.png">