### PR TITLE
Anpassung Icon Dashboard #2

### DIFF
--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -13,7 +13,7 @@
         <div class="card-body d-flex flex-wrap">
             <div class="align-self-center text-center user-icon rounded-circle mr-3 bg-primary text-white" style="width: 50px; height: 50px;">
                 <div class="d-flex align-items-center text-center h-100">
-                    <i class="far fa-user fa-2x mx-auto"></i>
+                    <i class="fas fa-user fa-2x mx-auto"></i>
                 </div>
             </div>
             <div class="align-self-center pr-5 mr-auto">


### PR DESCRIPTION
Selbes Problem wie bei: #35 

## Ansicht
Vorher:
<img width="289" alt="Bildschirmfoto 2021-08-31 um 08 13 39" src="https://user-images.githubusercontent.com/74987472/131463774-cff83539-e47a-41ca-921f-fbe14b06f2ae.png">
Nachher:
<img width="308" alt="Bildschirmfoto 2021-08-31 um 08 12 32" src="https://user-images.githubusercontent.com/74987472/131463771-51a10e3f-3f2c-4e09-9935-220c1b6817a2.png">
