### PR TITLE
Update Menu Icons

### DIFF
--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -84,7 +84,7 @@ class Builder {
         $menu->addChild('wiki.label', [
             'route' => 'wiki'
         ])
-            ->setExtra('icon', 'fab fa-wikipedia-w');
+            ->setExtra('icon', 'fas fa-book-open');
 
 
         return $menu;

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -73,7 +73,7 @@ class Builder {
         $menu->addChild('status.label', [
             'route' => 'current_status'
         ])
-            ->setExtra('icon', 'far fa-question-circle');
+            ->setExtra('icon', 'fas fa-question-circle');
 
         $menu->addChild('announcements.label', [
             'route' => 'announcements'

--- a/src/Menu/Builder.php
+++ b/src/Menu/Builder.php
@@ -84,7 +84,7 @@ class Builder {
         $menu->addChild('wiki.label', [
             'route' => 'wiki'
         ])
-            ->setExtra('icon', 'fas fa-book-open');
+            ->setExtra('icon', 'fab fa-wikipedia-w');
 
 
         return $menu;


### PR DESCRIPTION
Durch #35 wurde das Icon für die Gesamtstatusseite auf dem Dashboard geändert. Dieser Pull führt die gleiche Änderung für das Icon der Statusseite in der Navigationsleiste aus.

Zudem wird das Icon des Wikis in der Navigationsleiste und dem Dashboard vereinheitlicht.