### PR TITLE
Icon display error in dark mode

### DIFF
--- a/templates/dashboard/index.html.twig
+++ b/templates/dashboard/index.html.twig
@@ -34,7 +34,7 @@
     <div class="card-deck mt-3">
         <div class="card">
             <a href="{{ path('new_problem') }}" class="card-body d-flex align-items-center">
-                <div class="icon text-center mr-3 flex-shrink-0 bg-primary">
+                <div class="icon text-center mr-3 flex-shrink-0 bg-primary text-white">
                     <i class="fas fa-plus"></i>
                 </div>
                 <p class="m-0">{{ 'dashboard.problems.report'|trans }}</p>
@@ -43,7 +43,7 @@
 
         <div class="card">
             <a href="{{ path('current_status') }}" class="card-body d-flex align-items-center">
-                <div class="icon text-center mr-3 flex-shrink-0 bg-primary">
+                <div class="icon text-center mr-3 flex-shrink-0 bg-primary text-white">
                     <i class="fas fa-question-circle"></i>
                 </div>
                 <p class="m-0">{{ 'dashboard.status.overall'|trans }}</p>
@@ -52,7 +52,7 @@
 
         <div class="card">
             <a href="{{ path('problems') }}" class="card-body d-flex align-items-center">
-                <div class="icon text-center mr-3 flex-shrink-0 bg-primary">
+                <div class="icon text-center mr-3 flex-shrink-0 bg-primary text-white">
                     <i class="fas fa-exclamation-circle"></i>
                 </div>
                 <p class="m-0">{{ 'problems.label'|trans }}</p>
@@ -61,7 +61,7 @@
 
         <div class="card">
             <a href="{{ path('wiki') }}" class="card-body d-flex align-items-center">
-                <div class="icon text-center mr-3 flex-shrink-0 bg-primary">
+                <div class="icon text-center mr-3 flex-shrink-0 bg-primary text-white">
                     <i class="fas fa-book-open"></i>
                 </div>
                 <p class="m-0">{{ 'wiki.label'|trans }}</p>


### PR DESCRIPTION
# Problem
Der Hintergrund eines Icons im Dark-Mode ist fast weiß. Dies betrifft die 4. Cards unter dem User. Die Klasse `text-white` hilft hier, das ganze zu ändern. Im hellen Modus geschieht keine Änderung durch die Klasse.

# Beispiel
Vorher:
<img width="347" alt="Bildschirmfoto 2021-09-27 um 08 26 07" src="https://user-images.githubusercontent.com/74987472/134972615-82e884fd-902f-488f-8912-51121199d9b2.png">
Nachher:
<img width="343" alt="Bildschirmfoto 2021-09-27 um 08 25 58" src="https://user-images.githubusercontent.com/74987472/134972610-1054745e-f0e5-47e3-90aa-a5b44b95a58a.png">

