### PR TITLE
Vorschlag: Status Meldungen Übersicht 

### DIFF
--- a/templates/status/index.html.twig
+++ b/templates/status/index.html.twig
@@ -15,7 +15,7 @@
         <div class="row">
             <div class="col">
                 <div class="m-0 bs-callout bs-callout-{% if status.problemCount == 0 %}success{% else %}danger{% endif %}">
-                    <h4>{{ 'status.overview.header'|trans }}</h4>
+                    <h4>{{ 'status.overview.header1'|trans }}</h4>
                     <p>
                         {{ 'status.overview.problems'|trans({'%count%': status.problemCount })|raw }}
                     </p>
@@ -24,7 +24,7 @@
 
             <div class="col">
                 <div class="m-0 bs-callout bs-callout-{% if status.maintenanceCount == 0 %}success{% else %}warning{% endif %}">
-                    <h4>{{ 'status.overview.header'|trans }}</h4>
+                    <h4>{{ 'status.overview.header2'|trans }}</h4>
                     <p>
                         {{ 'status.overview.maintenance'|trans({ '%count%': status.maintenanceCount })|raw }}
                     </p>
@@ -33,7 +33,7 @@
 
             <div class="col">
                 <div class="m-0 bs-callout bs-callout-{% if status.announcementCount == 0 %}success{% else %}info{% endif %}">
-                    <h4>{{ 'status.overview.header'|trans }}</h4>
+                    <h4>{{ 'status.overview.header3'|trans }}</h4>
                     <p>
                         {{ 'status.overview.announcements'|trans({ '%count%': status.announcementCount })|raw }}
                     </p>

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -136,7 +136,9 @@ status:
     overview: Zurück zur Gesamt-Übersicht
     room: Zurück zur Raum-Übersicht
   overview:
-    header: Zusammenfassung
+    header1: Probleme
+    header2: Wartungsarbeiten
+    header3: Ankündigungen
     header_details: "Zusammenfassung für %target%"
     problems: "{0} Aktuell gibt es <strong>0</strong> Probleme.|{1} Aktuell gibt es <strong>1</strong> Problem.|]1,Inf[ Aktuell gibt es <strong>%count%</strong> Probleme."
     announcements: "{0} Aktuell gibt es <strong>0</strong> Ankündigungen.|{1} Aktuell gibt es <strong>1</strong> Ankündigung.|]1,Inf[ Aktuell gibt es <strong>%count%</strong> Ankündigungen."


### PR DESCRIPTION
# Idee
Die Überschrift "Zusammenfassung" sieht drei mal nebeneinander nicht so schön aus. Deswegen hier ein Vorschlag zur Anpassung.

# Ansicht
Vorher:
<img width="1420" alt="Bildschirmfoto 2021-09-28 um 17 31 21" src="https://user-images.githubusercontent.com/74987472/135118708-651d4203-7682-4326-aecd-57c78e85f090.png">

Nachher:
<img width="1424" alt="Bildschirmfoto 2021-09-28 um 17 32 35" src="https://user-images.githubusercontent.com/74987472/135118719-37c47807-5b30-412b-8f38-2f9469771399.png">
