### PR TITLE
Update Image Class

### DIFF
--- a/src/Markdown/Processors/ImageProcessor.php
+++ b/src/Markdown/Processors/ImageProcessor.php
@@ -24,7 +24,7 @@ class ImageProcessor {
                 continue;
             }
 
-            $node->data['attributes']['class'] = 'img-responsive';
+            $node->data['attributes']['class'] = 'img-fluid';
             $node->data['attributes']['style'] = 'margin: 5px 0px;';
         }
     }


### PR DESCRIPTION
# Problem
Bilder nicht innerhalb des Rahmens. Bild wird in Originalgröße angezeigt. Somit oft viel zu groß für den Rahmen.

## Vorher
![Bildschirmfoto 2022-03-13 um 20 51 29](https://user-images.githubusercontent.com/74987472/158076598-8b1aee9c-afba-41a5-b1ce-090c766359cd.png)

# Änderung
Klasse `img-responsive` nicht vorhanden. Klasse `img-fluid` setzt maximale Breite auf 100% des Rahmen.

## Nachher
![Bildschirmfoto 2022-03-13 um 20 51 47](https://user-images.githubusercontent.com/74987472/158076665-ad463d61-6f62-4f07-b4dc-445fa16895c5.png)

