### PR TITLE
Problembeschreibung Überschrift (H2)

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -268,3 +268,11 @@ blockquote footer {
     column-count: 1;
   }
 }
+
+.card-body h2{
+  font-size: 2rem !important;
+  font-weight: 500 !important;
+  margin-bottom: .5em !important;
+  line-height: 1.2 !important;
+  padding: 0 !important;
+}


### PR DESCRIPTION
# Problem
Bei einem Problemeintrag wird jede H2 falsch formatiert.

# Ansicht
## Vorher
<img width="917" alt="Bildschirmfoto 2022-03-14 um 11 58 29" src="https://user-images.githubusercontent.com/74987472/158173476-0c158888-97ec-40e8-b0d9-446fa9c1712f.png">

## Nachher
<img width="908" alt="Bildschirmfoto 2022-03-14 um 11 58 39" src="https://user-images.githubusercontent.com/74987472/158173479-4263481d-8050-4f07-a08e-50b60439dd80.png">

# Code
## Vorher
<img width="259" alt="Bildschirmfoto 2022-03-14 um 11 57 48" src="https://user-images.githubusercontent.com/74987472/158173470-e3c9c1ba-f29c-4e03-bc28-fab3f598632e.png">

## Idee Nachher
<img width="256" alt="Bildschirmfoto 2022-03-14 um 11 57 39" src="https://user-images.githubusercontent.com/74987472/158173460-4b753355-18f4-47ca-a4de-9d9d6646e07e.png">