### PR TITLE
Show closed problems in latestProblems

### DIFF
--- a/src/Repository/ProblemRepository.php
+++ b/src/Repository/ProblemRepository.php
@@ -373,8 +373,6 @@ class ProblemRepository implements ProblemRepositoryInterface {
             $qb->andWhere('p.isMaintenance = false');
         }
 
-        $this->filterClosedProblems($qb);
-
         return $qb->getQuery()->getResult();
     }
 }


### PR DESCRIPTION
Vorschlag: Meines Erachtens nach sollten geschlossene Probleme auch in der Neueste Probleme-Liste auf dem Dashboard angezeigt werden. So weiß zum einen die IT-Abteilung auf den ersten Blick ob ein kürzlich erstelltes Problem schon behoben wurde, und zum anderen sehen die Lehrkräfte, dass die IT-Abteilung nicht nur faul rumsitzt sondern eingestellte Probleme auch aktiv und zeitnah bearbeitet.
Ganz nebenbei macht dann die Spalte Status erstmal Sinn, da aktuell der Status logischerweise immer auf offen steht.
Sollte der Pull nicht angenommen werden, schlage ich daher vor die Spalte Status aus Neuste Probleme zu entfernen. 

Der Pull setzt den Vorschlag um.