### PR TITLE
Bande Farbe im Dark Mode

### DIFF
--- a/src/Converter/PriorityClassConverter.php
+++ b/src/Converter/PriorityClassConverter.php
@@ -10,7 +10,7 @@ class PriorityClassConverter {
         $map = [
             'danger' => Priority::Critical(),
             'warning' => Priority::High(),
-            'primary' => Priority::Normal()
+            'info' => Priority::Normal()
         ];
 
         foreach($map as $class => $priority) {


### PR DESCRIPTION
Im Dark Mode sind die Badges mit "normalem" Status quasi nicht sichtbar:

<img width="445" alt="Bagde1" src="https://user-images.githubusercontent.com/74987472/190334146-e1c4467f-30cc-4cf9-bd08-15ef81ddf4ea.png">
<img width="126" alt="Bagde4" src="https://user-images.githubusercontent.com/74987472/190334467-906e41e9-b13a-44a6-a0da-cdfcc5fcdba5.png">
<img width="108" alt="Bagde5" src="https://user-images.githubusercontent.com/74987472/190334471-7d88671d-5cf0-4b37-b69b-b098034d076c.png">


Hier würde ich empfehlen das Info badge zu verwenden:

<img width="451" alt="Bagde2" src="https://user-images.githubusercontent.com/74987472/190334168-39e97c24-9293-4a07-a330-d62dc68c4d9f.png">

<img width="130" alt="image" src="https://user-images.githubusercontent.com/74987472/190334597-802ca59f-f68d-4870-80eb-2e953c04cfe4.png">
<img width="359" alt="image" src="https://user-images.githubusercontent.com/74987472/190334678-da433847-63a8-4a82-835f-a7704299b785.png">

Eventuell müsste man noch entscheiden, ob man das Info Badge nur im Dark Mode zu verwenden. Dann müsste man im [app.scss](https://github.com/SchulIT/servicecenter/blob/master/assets/css/app.scss) folgendes ergänzen:

```scss
[data-theme=dark] .badge-outline-primary{
    border: 1px solid #17a2b8;
    color: #17a2b8;
}
```