### PR TITLE
bulk-delete problems as super-administrator

### DIFF
--- a/templates/problems/index.html.twig
+++ b/templates/problems/index.html.twig
@@ -141,6 +141,9 @@
                                         <option value="set_maintenance">{{ 'problems.bulk.maintenance.label'|trans }}</option>
                                         <option value="unset_maintenance">{{ 'problems.bulk.problem.label'|trans }}</option>
                                         <option value="assignee">{{ 'problems.bulk.take.label'|trans }}</option>
+                                        {% if is_granted('ROLE_SUPER_ADMIN') %}
+                                            <option value="remove_problem">{{ 'problems.bulk.remove.label'|trans }}</option>
+                                        {% endif %}
                                     </select>
                                     <input type="hidden" name="_csrf_token" value="{{ csrfTokenBulk }}" />
                                     <span class="input-group-append">

--- a/translations/messages.de.yml
+++ b/translations/messages.de.yml
@@ -111,6 +111,8 @@ problems:
       label: als Problem markieren
     take:
       label: übernehmen
+    remove:
+      label: endgültig löschen
     success: "{0} %num% Probleme aktualisiert|{1} 1 Problem aktualisiert|]1,Inf[ %count% Probleme aktualisiert"
     csrf: Massen-Aktion konnte nicht ausgeführt werden, da das CSRF-Token ungültig ist. Bitte erneut probieren.
   status:


### PR DESCRIPTION
Superadministratoren sollten die Möglichkeit haben mehrere Probleme in der Problemliste zu markieren und anschließend über die Sidebar endgültig zu löschen.

Das wäre vor allem hilfreich in Situationen, in denen das SC Nutzern vorgestellt wird und diese je ein Beispielproblem erstellen. Aktuell muss man dann jedes Problem einzeln anwählen, auf löschen drücken und bestätigen...